### PR TITLE
access array offsets using square brackets

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -30,7 +30,7 @@ s2p ($s)
 {
     $p = '';
     for ($i = 0; $i < strlen ($s); $i++)
-        $p .= $s{$i} . '/';
+        $p .= $s[$i] . '/';
     return $p;
 }
 
@@ -64,14 +64,14 @@ base_16_to_64 ($num)
     # Convert long hex string to bin.
     $size = strlen ($num);
     for ($i = 0; $i < $size; $i++)
-        $b .= $hex2bin{hexdec ($num{$i})};
+        $b .= $hex2bin[hexdec ($num[$i])];
     # Convert long bin to base 64.
     $size *= 4;
     for ($i = $size - 6; $i >= 0; $i -= 6)
-        $o = $m{bindec (substr ($b, $i, 6))} . $o;
+        $o = $m[bindec (substr ($b, $i, 6))] . $o;
     # Some few bits remaining ?
     if ($i < 0 && $i > -6)
-        $o = $m{bindec (substr ($b, 0, $i + 6))} . $o;
+        $o = $m[bindec (substr ($b, 0, $i + 6))] . $o;
     return $o;
 }
 


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate_curly_braces_array_access

s42 transfer doesn't work on PHP > 7.4 because of usage of curly braces. This PR changes some of the curly braces to square brackets to make the script work on the newest PHP versions.